### PR TITLE
Fix deepslate blockstate and model files

### DIFF
--- a/assets/minecraft/blockstates/deepslate.json
+++ b/assets/minecraft/blockstates/deepslate.json
@@ -1,0 +1,20 @@
+{
+  "variants": {
+    "": [
+      {
+        "model": "minecraft:block/deepslate"
+      },
+      {
+        "model": "minecraft:block/deepslate_mirrored"
+      },
+      {
+        "model": "minecraft:block/deepslate",
+        "y": 180
+      },
+      {
+        "model": "minecraft:block/deepslate_mirrored",
+        "y": 180
+      }
+    ]
+  }
+}

--- a/assets/minecraft/blockstates/deepslate.json
+++ b/assets/minecraft/blockstates/deepslate.json
@@ -1,20 +1,20 @@
 {
-  "variants": {
-    "": [
-      {
-        "model": "minecraft:block/deepslate"
-      },
-      {
-        "model": "minecraft:block/deepslate_mirrored"
-      },
-      {
-        "model": "minecraft:block/deepslate",
-        "y": 180
-      },
-      {
-        "model": "minecraft:block/deepslate_mirrored",
-        "y": 180
-      }
-    ]
-  }
+	"variants": {
+		"": [
+			{
+				"model": "minecraft:block/deepslate"
+			},
+			{
+				"model": "minecraft:block/deepslate_mirrored"
+			},
+			{
+				"model": "minecraft:block/deepslate",
+				"y": 180
+			},
+			{
+				"model": "minecraft:block/deepslate_mirrored",
+				"y": 180
+			}
+		]
+	}
 }

--- a/assets/minecraft/models/block/deepslate.json
+++ b/assets/minecraft/models/block/deepslate.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/cube_all",
+  "textures": {
+    "all": "minecraft:block/deepslate"
+  }
+}

--- a/assets/minecraft/models/block/deepslate.json
+++ b/assets/minecraft/models/block/deepslate.json
@@ -1,6 +1,6 @@
 {
-  "parent": "minecraft:block/cube_all",
-  "textures": {
-    "all": "minecraft:block/deepslate"
-  }
+	"parent": "minecraft:block/cube_all",
+	"textures": {
+		"all": "minecraft:block/deepslate"
+	}
 }

--- a/assets/minecraft/models/block/deepslate_mirrored.json
+++ b/assets/minecraft/models/block/deepslate_mirrored.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/cube_mirrored_all",
+  "textures": {
+    "all": "minecraft:block/deepslate"
+  }
+}

--- a/assets/minecraft/models/block/deepslate_mirrored.json
+++ b/assets/minecraft/models/block/deepslate_mirrored.json
@@ -1,6 +1,6 @@
 {
-  "parent": "minecraft:block/cube_mirrored_all",
-  "textures": {
-    "all": "minecraft:block/deepslate"
-  }
+	"parent": "minecraft:block/cube_mirrored_all",
+	"textures": {
+		"all": "minecraft:block/deepslate"
+	}
 }


### PR DESCRIPTION
- Makes deepslate blockstate and model the same as stone, fixing the missing top texture.

- [x] **I have made and am willing to license my contribution under the MIT license, or have permission from the original author to license it under MIT.**
